### PR TITLE
fix: declare @types/eslint and @types/estree as optional peer deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.1
+
+- fix: declare `@types/eslint` and `@types/estree` as optional peer deps so consumer types resolve correctly under pnpm. No runtime or type-shape changes.
+
 ## 1.1.0
 
 - Added TypeScript declarations (`index.d.ts`). No runtime changes.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-traverse",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Create a sub-traversal of an AST node in your ESLint plugin",
   "main": "index.js",
   "types": "index.d.ts",
@@ -37,6 +37,14 @@
     "babylon",
     "plugin"
   ],
+  "peerDependencies": {
+    "@types/eslint": "*",
+    "@types/estree": "*"
+  },
+  "peerDependenciesMeta": {
+    "@types/eslint": { "optional": true },
+    "@types/estree": { "optional": true }
+  },
   "devDependencies": {
     "@types/eslint": "^9.6.1",
     "@types/estree": "^1.0.9"


### PR DESCRIPTION
* `index.d.ts` imports types from `eslint` and `estree`, but those `@types/*` packages are only listed as `devDependencies`. 
   * Consumers end up resolving the bare imports against whichever version of them happens to be in their `node_modules` (often pulled in transitively by something unrelated - in our case: `eslint-webpack-plugin`, `@types/eslint-scope`).

* When that version doesn't line up with the one the consumer expects, TS ends up with two incompatible copies of the same types, and every `traverse(context, ...)` call site reports a type mismatch.
   * Fixed using this pattern https://github.com/prettier/eslint-plugin-prettier/blob/main/package.json#L64 which seems to be the "right/common" way.